### PR TITLE
Enhance detection of code language for Accept-Language header

### DIFF
--- a/starlette_i18n/i18n.py
+++ b/starlette_i18n/i18n.py
@@ -62,7 +62,7 @@ def _parse_accept_language(value: str) -> t.List[t.Tuple[str, str]]:
             accepted_languages.append((language, "1"))
         else:
             _, weight = parts[1].strip().split("=")
-            accepted_languages.append((parts[0].strip(), weight))
+            accepted_languages.append((parts[0].strip().replace("-", "_"), weight))
 
     return accepted_languages
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_success_if_en_locale(client):
     response = client.get("/success/", headers={"Accept-Language": "en"})
     assert response.status_code == 200
@@ -28,7 +31,17 @@ def test_success_if_not_support_locale(client):
     assert response.text == "Success"
 
 
-def test_success_if_empty_locale_gheader(client):
+@pytest.mark.parametrize(
+    ("language", "success"),
+    [("ru, fr;q=0.8", "Успех"), ("fr, it;q=0.7", "Success"), ("fr, en;q=0.8", "Success")],
+)
+def test_success_if_multiple_locales_in_header(client, language, success):
+    response = client.get("/success/", headers={"Accept-Language": language})
+    assert response.status_code == 200
+    assert response.text == success
+
+
+def test_success_if_empty_locale_header(client):
     response = client.get("/success/")
     assert response.status_code == 200
     assert response.text == "Success"


### PR DESCRIPTION
Hi,
when looking at your code, I saw that you are always assuming that the header `Accept-Language` will have one value such as `en` or `ru` but in many cases, this will not be the case. If you look at the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) of this header, you  will notice that it can have a form like `en-US,en;q=0.5,fr;q=0.4` and therefore `LocalMiddleware` will be unable to detect the right language.

My pull request aims to solve that issue and I have added related tests